### PR TITLE
Fix openai key loading and image path

### DIFF
--- a/mixologist/services/openai_service.py
+++ b/mixologist/services/openai_service.py
@@ -1,4 +1,5 @@
 import openai
+import os
 import json
 import logging
 from collections import namedtuple
@@ -6,7 +7,14 @@ from ..models import GetRecipeParams
 import re 
 import requests 
 
-openai.api_key = ""
+# Load an API key from the environment if available.  Leaving
+# ``openai.api_key`` empty overrides the library's built in behaviour of
+# reading ``OPENAI_API_KEY`` from the environment, so we explicitly pull
+# the value here instead.
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
 Recipe = namedtuple("Recipe", ["ingredients", "alcohol_content", "steps", "rim", "garnish", "serving_glass", "drink_image_description", "drink_history", "drink_name"])
 
 # Set up logging

--- a/mixologist/views/bartender.py
+++ b/mixologist/views/bartender.py
@@ -38,7 +38,8 @@ def create_drink():
 
 @bp.route('/images')
 def images():
-    img_dir = 'bartender_app/static/'
+    """List available images in the application's static folder."""
+    img_dir = os.path.join('mixologist', 'static', 'img')
     return jsonify(os.listdir(img_dir))
 
 @bp.route('/generate_image', methods=['POST'])


### PR DESCRIPTION
## Summary
- load OPENAI_API_KEY from environment instead of overriding with empty string
- correct image listing path

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f64e7b8f08321aaa5202282b6c3a9