### PR TITLE
Improve image generation with GPT Image

### DIFF
--- a/mixologist/templates/create_drinks.html
+++ b/mixologist/templates/create_drinks.html
@@ -61,7 +61,13 @@
     <script>
         $(document).ready(function() {
             // Use AJAX to generate the image after the page has loaded
-            $.post('/generate_image', {image_description: '{{drink_image_description}}', drink_query: '{{drink_name}}'}, function(data) {
+            const payload = {
+                image_description: '{{drink_image_description}}',
+                drink_query: '{{drink_name}}',
+                serving_glass: '{{serving_glass}}',
+                ingredients: {{ ingredients | tojson }}
+            };
+            $.post('/generate_image', payload, function(data) {
                 // Update the source of the image element with the new filename
                 $('#drinkImage').attr('src', '/static/img/' + data.filename);
             });

--- a/mixologist/views/bartender.py
+++ b/mixologist/views/bartender.py
@@ -43,15 +43,22 @@ def images():
     return jsonify(os.listdir(img_dir))
 
 @bp.route('/generate_image', methods=['POST'])
-def generate_image_route():
-    # Extract the image description and drink query from the request
+async def generate_image_route():
+    """Generate an image for the drink asynchronously."""
     image_description = request.form.get('image_description')
     drink_query = request.form.get('drink_query')
+    ingredients_json = request.form.get('ingredients')
+    serving_glass = request.form.get('serving_glass')
 
-    # Generate the image and get the filename
-    filename = generate_image(image_description, drink_query)
+    ingredients = json.loads(ingredients_json) if ingredients_json else None
 
-    # Return the filename in the response
+    filename = await generate_image(
+        image_description,
+        drink_query,
+        ingredients=ingredients,
+        serving_glass=serving_glass,
+    )
+
     return jsonify({"filename": filename})
 
 


### PR DESCRIPTION
## Summary
- use `gpt-image-1` instead of DALL‑E 3 for higher quality images
- remove deprecated style arg and keep async client
- retain detailed prompt when building drink images

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f6bd40f3c83219a919d5d6197b863