### PR TITLE
Implement method image generation pipeline

### DIFF
--- a/mixologist/services/__init__.py
+++ b/mixologist/services/__init__.py
@@ -1,1 +1,6 @@
-from .openai_service import get_completion_from_messages, parse_recipe_arguments
+from .openai_service import (
+    get_completion_from_messages,
+    parse_recipe_arguments,
+    extract_visual_moments,
+    generate_method_image_stream,
+)


### PR DESCRIPTION
## Summary
- add prompt templates and context extraction for method steps
- stream method step technique images through new FastAPI endpoint
- export new API in services package
- adjust unit tests with flask stubs and new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427440633083219a0568eed117b1f1