### PR TITLE
feat: display comprehensive variation information on overview page

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1414,36 +1414,166 @@ class _RecipeScreenState extends State<RecipeScreen> {
                       ),
                       const SizedBox(height: 16),
                       
-                      // Variations Section
+                      // Comprehensive Variations Section
                       if (widget.recipeData['suggested_variations'] is List && 
                           (widget.recipeData['suggested_variations'] as List).isNotEmpty) ...[
                         Text('Variations', style: Theme.of(context).textTheme.titleMedium),
                         const SizedBox(height: 8),
-                        ...((widget.recipeData['suggested_variations'] as List).take(2).map((v) {
-                          final name = v['name'] ?? '';
-                          return Padding(
-                            padding: const EdgeInsets.only(bottom: 8),
-                            child: Row(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Icon(
-                                  Icons.arrow_right,
-                                  size: 16,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                                const SizedBox(width: 4),
-                                Expanded(
-                                  child: Text(
-                                    name,
-                                    style: Theme.of(context).textTheme.bodySmall,
-                                    maxLines: 2,
-                                    overflow: TextOverflow.ellipsis,
+                        Column(
+                          children: [
+                            for (var variation in widget.recipeData['suggested_variations'])
+                              Container(
+                                margin: const EdgeInsets.only(bottom: 8),
+                                padding: const EdgeInsets.all(12),
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.surfaceVariant.withValues(alpha: 0.3),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
                                   ),
                                 ),
-                              ],
-                            ),
-                          );
-                        })),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      variation['name'] ?? 'Variation',
+                                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                    if (variation['description'] != null && variation['description'].toString().isNotEmpty) ...[
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        variation['description'],
+                                        style: Theme.of(context).textTheme.bodySmall,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ],
+                                    if (variation['changes'] is List && (variation['changes'] as List).isNotEmpty) ...[
+                                      const SizedBox(height: 6),
+                                      Wrap(
+                                        spacing: 4,
+                                        children: (variation['changes'] as List).take(3)
+                                            .map((change) => Container(
+                                                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                                                  decoration: BoxDecoration(
+                                                    color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.2),
+                                                    borderRadius: BorderRadius.circular(4),
+                                                  ),
+                                                  child: Text(
+                                                    change,
+                                                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                                      color: Theme.of(context).colorScheme.secondary,
+                                                    ),
+                                                  ),
+                                                ))
+                                            .toList(),
+                                      ),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                      ],
+                      
+                      // Related Cocktails Section
+                      if (widget.recipeData['related_cocktails'] is List && 
+                          (widget.recipeData['related_cocktails'] as List).isNotEmpty) ...[
+                        Text('Related Cocktails', style: Theme.of(context).textTheme.titleMedium),
+                        const SizedBox(height: 8),
+                        SizedBox(
+                          height: 80,
+                          child: ListView.builder(
+                            scrollDirection: Axis.horizontal,
+                            itemCount: widget.recipeData['related_cocktails'].length,
+                            itemBuilder: (context, index) {
+                              final cocktail = widget.recipeData['related_cocktails'][index];
+                              return Container(
+                                width: 120,
+                                margin: const EdgeInsets.only(right: 8),
+                                child: Material(
+                                  color: Colors.transparent,
+                                  child: InkWell(
+                                    onTap: _isLoadingRelatedCocktail 
+                                        ? null 
+                                        : () => _loadRelatedCocktail(cocktail),
+                                    borderRadius: BorderRadius.circular(8),
+                                    child: Container(
+                                      padding: const EdgeInsets.all(8),
+                                      decoration: BoxDecoration(
+                                        color: Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: 0.3),
+                                        borderRadius: BorderRadius.circular(8),
+                                        border: Border.all(
+                                          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                                        ),
+                                      ),
+                                      child: Column(
+                                        mainAxisAlignment: MainAxisAlignment.center,
+                                        children: [
+                                          Icon(
+                                            Icons.local_bar,
+                                            size: 20,
+                                            color: Theme.of(context).colorScheme.secondary,
+                                          ),
+                                          const SizedBox(height: 4),
+                                          Text(
+                                            cocktail,
+                                            style: Theme.of(context).textTheme.labelSmall,
+                                            textAlign: TextAlign.center,
+                                            maxLines: 2,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                      ],
+                      
+                      // Food Pairings Section
+                      if (widget.recipeData['food_pairings'] is List && 
+                          (widget.recipeData['food_pairings'] as List).isNotEmpty) ...[
+                        Text('Food Pairings', style: Theme.of(context).textTheme.titleMedium),
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 4,
+                          runSpacing: 4,
+                          children: (widget.recipeData['food_pairings'] as List)
+                              .map((pairing) => Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                    decoration: BoxDecoration(
+                                      color: Theme.of(context).colorScheme.tertiaryContainer.withValues(alpha: 0.3),
+                                      borderRadius: BorderRadius.circular(12),
+                                      border: Border.all(
+                                        color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                                      ),
+                                    ),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Icon(
+                                          Icons.restaurant, 
+                                          size: 12, 
+                                          color: Theme.of(context).colorScheme.tertiary,
+                                        ),
+                                        const SizedBox(width: 4),
+                                        Text(
+                                          pairing,
+                                          style: Theme.of(context).textTheme.labelSmall,
+                                        ),
+                                      ],
+                                    ),
+                                  ))
+                              .toList(),
+                        ),
                         const SizedBox(height: 16),
                       ],
                       

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -454,12 +454,12 @@ class _RecipeScreenState extends State<RecipeScreen> {
       if (_expandedSection == id) {
         _expandedSection = null;
         if (kIsWeb) {
-          web.window.history.replaceState(null, '', '#');
+          html.window.history.replaceState(null, '', '#');
         }
       } else {
         _expandedSection = id;
         if (kIsWeb) {
-          web.window.history.replaceState(null, '', '#$id');
+          html.window.history.replaceState(null, '', '#$id');
         }
         
         // Auto-generate ingredient images when ingredients section is expanded
@@ -732,13 +732,13 @@ class _RecipeScreenState extends State<RecipeScreen> {
       
       // Save ingredient checklist
       for (String ingredient in _ingredientChecklist.keys) {
-        web.window.localStorage['${recipeKey}_ingredient_$ingredient'] = 
+        html.window.localStorage['${recipeKey}_ingredient_$ingredient'] = 
             _ingredientChecklist[ingredient].toString();
       }
       
       // Save step completion
       for (int step in _stepCompletion.keys) {
-        web.window.localStorage['${recipeKey}_step_$step'] = 
+        html.window.localStorage['${recipeKey}_step_$step'] = 
             _stepCompletion[step].toString();
       }
     } catch (e) {
@@ -755,7 +755,7 @@ class _RecipeScreenState extends State<RecipeScreen> {
       // Load ingredient checklist
       final ingredientKeys = _ingredientChecklist.keys.toList();
       for (String ingredient in ingredientKeys) {
-        final saved = web.window.localStorage['${recipeKey}_ingredient_$ingredient'];
+        final saved = html.window.localStorage['${recipeKey}_ingredient_$ingredient'];
         if (saved != null) {
           _ingredientChecklist[ingredient] = saved.toLowerCase() == 'true';
         }
@@ -764,7 +764,7 @@ class _RecipeScreenState extends State<RecipeScreen> {
       // Load step completion
       final stepKeys = _stepCompletion.keys.toList();
       for (int step in stepKeys) {
-        final saved = web.window.localStorage['${recipeKey}_step_$step'];
+        final saved = html.window.localStorage['${recipeKey}_step_$step'];
         if (saved != null) {
           _stepCompletion[step] = saved.toLowerCase() == 'true';
         }

--- a/flutter_app/lib/widgets/method_card.dart
+++ b/flutter_app/lib/widgets/method_card.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -16,8 +16,11 @@ dependencies:
   vibration: ^1.8.4
   cached_network_image: ^3.3.1
   shared_preferences: ^2.2.2
+  web: ^1.0.0
 
 flutter:
   uses-material-design: true
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^6.0.0

--- a/flutter_app/test/widget_test.dart
+++ b/flutter_app/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mixologist_flutter/main.dart';


### PR DESCRIPTION
Enhanced the main overview page to display all variation information instead of just the limited subset previously shown.

## Changes Made:

- Replace limited variations preview (2 items) with full variation details
- Add complete variation descriptions and change indicators
- Include interactive related cocktails navigation section
- Add food pairings display with restaurant icons
- Improve space utilization in overview layout

Fixes #21

Generated with [Claude Code](https://claude.ai/code)