### PR TITLE
Fix method card widget syntax and checkbox handling

### DIFF
--- a/flutter_app/lib/widgets/method_card.dart
+++ b/flutter_app/lib/widgets/method_card.dart
@@ -298,7 +298,8 @@ class _MethodCardState extends State<MethodCard>
                 color: Colors.grey[500],
               ),
               textAlign: TextAlign.center,
-                  ),
+            ),
+          ],
         ),
       ),
     );
@@ -436,7 +437,11 @@ class _MethodCardState extends State<MethodCard>
                     alignment: Alignment.centerRight,
                     child: Checkbox(
                       value: widget.data.isCompleted,
-                      onChanged: widget.onCheckboxChanged,
+                      onChanged: (value) {
+                        if (widget.onCheckboxChanged != null) {
+                          widget.onCheckboxChanged!(value ?? false);
+                        }
+                      },
                       activeColor: theme.colorScheme.secondary,
                       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     ),


### PR DESCRIPTION
## Summary
- fix unmatched bracket in `_buildPlaceholderWidget`
- adapt checkbox onChanged handler to accept nullable bool

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68437d8da0a48321bc53392ee1492012