### PR TITLE
fix: resolve Flask import conflicts in tests

### DIFF
--- a/debug_test.py
+++ b/debug_test.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Simple debug script to identify test issues without running pytest directly.
+"""
+
+import sys
+import os
+import traceback
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__))))
+
+def test_basic_imports():
+    """Test basic imports to identify import issues."""
+    print("Testing basic imports...")
+    
+    try:
+        # Test environment setup
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-12345")
+        print("✓ Environment setup complete")
+        
+        # Test basic module imports
+        import mixologist
+        print("✓ mixologist module imported")
+        
+        import mixologist.models
+        print("✓ mixologist.models imported")
+        
+        from mixologist.models.get_recipe_params import GetRecipeParams, Ingredient
+        print("✓ GetRecipeParams and Ingredient imported")
+        
+        # Test service imports
+        import mixologist.services
+        print("✓ mixologist.services imported")
+        
+        from mixologist.services.openai_service import Recipe, parse_recipe_arguments
+        print("✓ Recipe and parse_recipe_arguments imported")
+        
+        print("All basic imports successful!")
+        return True
+        
+    except Exception as e:
+        print(f"✗ Import failed: {e}")
+        traceback.print_exc()
+        return False
+
+def test_recipe_construction():
+    """Test Recipe namedtuple construction."""
+    print("\nTesting Recipe construction...")
+    
+    try:
+        from mixologist.services.openai_service import Recipe
+        
+        # Test construction with all 24 fields
+        recipe = Recipe(
+            [], 0.2, [], False, [], "", "", "", "Test Cocktail",
+            [], [], [], 0, 0, [], None, None, {}, [], [], [], "", "", []
+        )
+        
+        print(f"✓ Recipe created successfully: {recipe.drink_name}")
+        print(f"✓ Recipe has {len(recipe._fields)} fields")
+        
+        # Verify all expected fields exist
+        expected_fields = [
+            "ingredients", "alcohol_content", "steps", "rim", "garnish", "serving_glass", 
+            "drink_image_description", "drink_history", "drink_name",
+            "brand_recommendations", "ingredient_substitutions", "related_cocktails",
+            "difficulty_rating", "preparation_time_minutes", "equipment_needed",
+            "flavor_profile", "serving_size_base", "phonetic_pronunciations",
+            "enhanced_steps", "suggested_variations", "food_pairings",
+            "optimal_serving_temperature", "skill_level_recommendation", "drink_trivia"
+        ]
+        
+        actual_fields = recipe._fields
+        print(f"✓ Expected {len(expected_fields)} fields, got {len(actual_fields)}")
+        
+        if set(expected_fields) == set(actual_fields):
+            print("✓ All fields match!")
+        else:
+            missing = set(expected_fields) - set(actual_fields)
+            extra = set(actual_fields) - set(expected_fields)
+            if missing:
+                print(f"✗ Missing fields: {missing}")
+            if extra:
+                print(f"✗ Extra fields: {extra}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Recipe construction failed: {e}")
+        traceback.print_exc()
+        return False
+
+def test_parse_recipe_arguments():
+    """Test parse_recipe_arguments function."""
+    print("\nTesting parse_recipe_arguments...")
+    
+    try:
+        from mixologist.services.openai_service import parse_recipe_arguments
+        
+        # Test with simple dict
+        test_data = {
+            "drink_name": "Test Cocktail",
+            "alcohol_content": 0.3,
+            "ingredients": ["2 oz Gin"],
+            "steps": ["Mix", "Serve"],
+            "rim": False,
+            "garnish": ["Lime"],
+            "serving_glass": "Coupe",
+            "drink_image_description": "Test description",
+            "drink_history": "Test history"
+        }
+        
+        recipe = parse_recipe_arguments(test_data)
+        print(f"✓ parse_recipe_arguments successful: {recipe.drink_name}")
+        
+        # Test with JSON string
+        import json
+        json_str = json.dumps(test_data)
+        recipe2 = parse_recipe_arguments(json_str)
+        print(f"✓ JSON parsing successful: {recipe2.drink_name}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ parse_recipe_arguments failed: {e}")
+        traceback.print_exc()
+        return False
+
+def test_flask_mocking():
+    """Test Flask mocking setup similar to tests."""
+    print("\nTesting Flask mocking...")
+    
+    try:
+        import types
+        
+        # Set up dummy Flask like in tests
+        dummy_flask = types.SimpleNamespace(
+            Flask=object,
+            Blueprint=lambda *a, **k: types.SimpleNamespace(
+                route=lambda *a, **k: (lambda f: f),
+                errorhandler=lambda *a, **k: (lambda f: f),
+                app_errorhandler=lambda *a, **k: (lambda f: f),
+            ),
+            request=None,
+            render_template_string=lambda *a, **k: "",
+            render_template=lambda *a, **k: "",
+            Response=object,
+            stream_with_context=lambda f: f,
+            jsonify=lambda *a, **k: {},
+        )
+        sys.modules.setdefault("flask", dummy_flask)
+        sys.modules.setdefault("flask_cors", types.SimpleNamespace(CORS=lambda *a, **k: None))
+        
+        print("✓ Flask mocking setup complete")
+        
+        # Now try importing bartender which uses Flask
+        from mixologist.views.bartender import bp
+        print("✓ Bartender blueprint imported successfully")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Flask mocking failed: {e}")
+        traceback.print_exc()
+        return False
+
+def main():
+    """Run all debug tests."""
+    print("=== Python Test Debug Script ===")
+    
+    tests = [
+        test_basic_imports,
+        test_recipe_construction,
+        test_parse_recipe_arguments,
+        test_flask_mocking,
+    ]
+    
+    results = []
+    for test in tests:
+        try:
+            result = test()
+            results.append(result)
+        except Exception as e:
+            print(f"✗ Test {test.__name__} crashed: {e}")
+            traceback.print_exc()
+            results.append(False)
+    
+    print(f"\n=== Summary ===")
+    print(f"Passed: {sum(results)}/{len(results)}")
+    
+    if all(results):
+        print("✓ All debug tests passed! The issue might be with test execution environment.")
+    else:
+        print("✗ Some debug tests failed. Check the errors above.")
+    
+    return all(results)
+
+if __name__ == "__main__":
+    main()

--- a/mixologist/__init__.py
+++ b/mixologist/__init__.py
@@ -1,9 +1,9 @@
-from flask import Flask
-from flask_cors import CORS # Import CORS
-from .views import bartender
-
 def create_app():
+    from flask import Flask
+    from flask_cors import CORS
+    from .views.bartender import get_blueprint
+    
     app = Flask(__name__)
     CORS(app) # Enable CORS for all routes and origins
-    app.register_blueprint(bartender.bp)
+    app.register_blueprint(get_blueprint())
     return app

--- a/mixologist/views/bartender.py
+++ b/mixologist/views/bartender.py
@@ -1,8 +1,6 @@
-from flask import Blueprint, request, render_template_string, render_template, Response, stream_with_context, jsonify
 import os
 import json
 import openai
-# from flask import jsonify # jsonify is already imported above
 from pydantic import BaseModel, Field
 from typing import List, Dict
 from collections import namedtuple
@@ -10,149 +8,166 @@ from dotenv import load_dotenv
 from ..models.get_recipe_params import Ingredient, GetRecipeParams
 from ..services.openai_service import Recipe, parse_recipe_arguments, get_completion_from_messages, generate_image_stream # Updated import
 
-bp = Blueprint('bartender', __name__)
+# Lazy initialization to avoid Flask import at module level
+_blueprint = None
 
-@bp.route('/')
-def home():
-    return render_template('home.html')
+def get_blueprint():
+    """Get or create the bartender blueprint."""
+    global _blueprint
+    if _blueprint is None:
+        from flask import Blueprint
+        _blueprint = Blueprint('bartender', __name__)
+        _register_routes()
+    return _blueprint
 
-@bp.route('/create', methods=['POST'])
-def create_drink():
-    drink_query = request.form.get('drink_query')
-    ingredients = "" # This seems unused or hardcoded empty, might need review later
-    ingredients_part = f"The ingredients I have are: {ingredients}\n" if ingredients else ""
-    user_query = f"""
-    I want you to act like the world's most important bartender. 
-    You're the bartender that will carry on the culture of bartending for the entire world. 
-    I'm going to tell you the name of a drink, and you need to create the best representation of that drink based on its name alone. 
-    It's possible that this drink is unknown; you will still respond. 
-    {ingredients_part}
-    The drink I want you to tell me about is: {drink_query}
-    """
-    recipe = get_completion_from_messages([{"role": "user", "content": user_query}])
-    recipe_data = {
-        # Original fields
-        "drink_name": recipe.drink_name,
-        "alcohol_content": recipe.alcohol_content,
-        "serving_glass": recipe.serving_glass,
-        "rim": 'Salted' if recipe.rim else 'No salt',
-        "ingredients": recipe.ingredients,
-        "steps": recipe.steps,
-        "garnish": recipe.garnish,
-        "drink_image_description": recipe.drink_image_description,
-        "drink_history": recipe.drink_history,
-        # Enhanced fields
-        "brand_recommendations": recipe.brand_recommendations,
-        "ingredient_substitutions": recipe.ingredient_substitutions,
-        "related_cocktails": recipe.related_cocktails,
-        "difficulty_rating": recipe.difficulty_rating,
-        "preparation_time_minutes": recipe.preparation_time_minutes,
-        "equipment_needed": recipe.equipment_needed,
-        "flavor_profile": recipe.flavor_profile,
-        "serving_size_base": recipe.serving_size_base,
-        "phonetic_pronunciations": recipe.phonetic_pronunciations,
-        "enhanced_steps": recipe.enhanced_steps,
-        "suggested_variations": recipe.suggested_variations,
-        "food_pairings": recipe.food_pairings,
-        "optimal_serving_temperature": recipe.optimal_serving_temperature,
-        "skill_level_recommendation": recipe.skill_level_recommendation
-    }
-    return jsonify(recipe_data)
-
-@bp.route('/images') # This route might be obsolete if images are always generated on demand
-def images():
-    img_dir = 'mixologist/static/img/'
-    # Ensure directory exists to prevent error if it's deleted or not yet created
-    if not os.path.exists(img_dir):
-        os.makedirs(img_dir)
-    return jsonify(os.listdir(img_dir))
-
-@bp.route('/generate_image', methods=['POST']) # This will now be our streaming endpoint
-def generate_image_route():
-    print("--- generate_image_route (streaming) called ---")
+def _register_routes():
+    """Register all routes on the blueprint."""
+    from flask import request, render_template_string, render_template, Response, stream_with_context, jsonify
+    import asyncio
     
-    image_description = request.form.get('image_description')
-    drink_query = request.form.get('drink_query') # drink_name for the image
-    ingredients_json = request.form.get('ingredients')
-    serving_glass = request.form.get('serving_glass')
-    
-    try:
-        ingredients = json.loads(ingredients_json) if ingredients_json else None
-    except json.JSONDecodeError:
-        print("!!! ERROR decoding ingredients JSON in generate_image_route !!!")
-        return jsonify({"error": "Invalid ingredients JSON format"}), 400
+    @_blueprint.route('/')
+    def home():
+        return render_template('home.html')
 
-    def event_stream():
-        import asyncio
-        
-        async def async_event_stream():
-            try:
-                print(f"--- Starting OpenAI image stream for: {drink_query} ---")
-                async for b64_image_chunk in generate_image_stream(
-                    image_description,
-                    drink_query,
-                    ingredients=ingredients,
-                    serving_glass=serving_glass,
-                ):
-                    sse_event = {"type": "partial_image", "b64_data": b64_image_chunk}
-                    yield f"data: {json.dumps(sse_event)}\n\n"
-                
-                # After the stream from OpenAI is finished, send a completion event
-                print(f"--- Finished streaming partial images for: {drink_query} ---")
-                yield f"data: {json.dumps({'type': 'stream_complete'})}\n\n"
+    @_blueprint.route('/create', methods=['POST'])
+    def create_drink():
+        drink_query = request.form.get('drink_query')
+        ingredients = "" # This seems unused or hardcoded empty, might need review later
+        ingredients_part = f"The ingredients I have are: {ingredients}\n" if ingredients else ""
+        user_query = f"""
+        I want you to act like the world's most important bartender. 
+        You're the bartender that will carry on the culture of bartending for the entire world. 
+        I'm going to tell you the name of a drink, and you need to create the best representation of that drink based on its name alone. 
+        It's possible that this drink is unknown; you will still respond. 
+        {ingredients_part}
+        The drink I want you to tell me about is: {drink_query}
+        """
+        recipe = get_completion_from_messages([{"role": "user", "content": user_query}])
+        recipe_data = {
+            # Original fields
+            "drink_name": recipe.drink_name,
+            "alcohol_content": recipe.alcohol_content,
+            "serving_glass": recipe.serving_glass,
+            "rim": 'Salted' if recipe.rim else 'No salt',
+            "ingredients": recipe.ingredients,
+            "steps": recipe.steps,
+            "garnish": recipe.garnish,
+            "drink_image_description": recipe.drink_image_description,
+            "drink_history": recipe.drink_history,
+            # Enhanced fields
+            "brand_recommendations": recipe.brand_recommendations,
+            "ingredient_substitutions": recipe.ingredient_substitutions,
+            "related_cocktails": recipe.related_cocktails,
+            "difficulty_rating": recipe.difficulty_rating,
+            "preparation_time_minutes": recipe.preparation_time_minutes,
+            "equipment_needed": recipe.equipment_needed,
+            "flavor_profile": recipe.flavor_profile,
+            "serving_size_base": recipe.serving_size_base,
+            "phonetic_pronunciations": recipe.phonetic_pronunciations,
+            "enhanced_steps": recipe.enhanced_steps,
+            "suggested_variations": recipe.suggested_variations,
+            "food_pairings": recipe.food_pairings,
+            "optimal_serving_temperature": recipe.optimal_serving_temperature,
+            "skill_level_recommendation": recipe.skill_level_recommendation
+        }
+        return jsonify(recipe_data)
 
-            except Exception as e:
-                print(f"!!! EXCEPTION in event_stream for generate_image_route: {type(e).__name__} - {str(e)} !!!")
-                import traceback
-                traceback.print_exc()
-                # Send an error event over SSE
-                error_event = {"type": "error", "message": str(e)}
-                yield f"data: {json.dumps(error_event)}\n\n"
+    @_blueprint.route('/images') # This route might be obsolete if images are always generated on demand
+    def images():
+        img_dir = 'mixologist/static/img/'
+        # Ensure directory exists to prevent error if it's deleted or not yet created
+        if not os.path.exists(img_dir):
+            os.makedirs(img_dir)
+        return jsonify(os.listdir(img_dir))
+
+    @_blueprint.route('/generate_image', methods=['POST']) # This will now be our streaming endpoint
+    def generate_image_route():
+        print("--- generate_image_route (streaming) called ---")
         
-        # Run the async generator in a synchronous context
+        image_description = request.form.get('image_description')
+        drink_query = request.form.get('drink_query') # drink_name for the image
+        ingredients_json = request.form.get('ingredients')
+        serving_glass = request.form.get('serving_glass')
+        
         try:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            async_gen = async_event_stream()
-            
-            while True:
+            ingredients = json.loads(ingredients_json) if ingredients_json else None
+        except json.JSONDecodeError:
+            print("!!! ERROR decoding ingredients JSON in generate_image_route !!!")
+            return jsonify({"error": "Invalid ingredients JSON format"}), 400
+
+        def event_stream():
+            async def async_event_stream():
                 try:
-                    result = loop.run_until_complete(async_gen.__anext__())
-                    yield result
-                except StopAsyncIteration:
-                    break
-        finally:
-            loop.close()
+                    print(f"--- Starting OpenAI image stream for: {drink_query} ---")
+                    async for b64_image_chunk in generate_image_stream(
+                        image_description,
+                        drink_query,
+                        ingredients=ingredients,
+                        serving_glass=serving_glass,
+                    ):
+                        sse_event = {"type": "partial_image", "b64_data": b64_image_chunk}
+                        yield f"data: {json.dumps(sse_event)}\n\n"
+                    
+                    # After the stream from OpenAI is finished, send a completion event
+                    print(f"--- Finished streaming partial images for: {drink_query} ---")
+                    yield f"data: {json.dumps({'type': 'stream_complete'})}\n\n"
 
-    return Response(stream_with_context(event_stream()), mimetype='text/event-stream')
+                except Exception as e:
+                    print(f"!!! EXCEPTION in event_stream for generate_image_route: {type(e).__name__} - {str(e)} !!!")
+                    import traceback
+                    traceback.print_exc()
+                    # Send an error event over SSE
+                    error_event = {"type": "error", "message": str(e)}
+                    yield f"data: {json.dumps(error_event)}\n\n"
+            
+            # Run the async generator in a synchronous context
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                async_gen = async_event_stream()
+                
+                while True:
+                    try:
+                        result = loop.run_until_complete(async_gen.__anext__())
+                        yield result
+                    except StopAsyncIteration:
+                        break
+            finally:
+                loop.close()
 
-import asyncio # Add for asyncio.sleep
+        return Response(stream_with_context(event_stream()), mimetype='text/event-stream')
 
-@bp.route('/test_async_stream')
-async def test_async_stream():
-    print("--- /test_async_stream called ---")
-    async def simple_generator():
-        for i in range(5):
-            print(f"--- /test_async_stream yielding item {i} ---")
-            await asyncio.sleep(0.2)
-            yield f"data: Test Event {i}\n\n"
-        print("--- /test_async_stream finished ---")
-    return Response(simple_generator(), mimetype='text/event-stream')
+    @_blueprint.route('/test_async_stream')
+    async def test_async_stream():
+        print("--- /test_async_stream called ---")
+        async def simple_generator():
+            for i in range(5):
+                print(f"--- /test_async_stream yielding item {i} ---")
+                await asyncio.sleep(0.2)
+                yield f"data: Test Event {i}\n\n"
+            print("--- /test_async_stream finished ---")
+        return Response(simple_generator(), mimetype='text/event-stream')
 
-@bp.errorhandler(openai.BadRequestError)
-def handle_invalid_request_error(e):
-    # This error handler might not be reached if exceptions are caught within routes
-    print(f"--- OpenAI BadRequestError Handler: {e} ---")
-    return jsonify({"error": "OpenAI BadRequestError", "details": str(e)}), 500
+    @_blueprint.errorhandler(openai.BadRequestError)
+    def handle_invalid_request_error(e):
+        # This error handler might not be reached if exceptions are caught within routes
+        print(f"--- OpenAI BadRequestError Handler: {e} ---")
+        return jsonify({"error": "OpenAI BadRequestError", "details": str(e)}), 500
 
-@bp.errorhandler(KeyError)
-def handle_key_error(e):
-    print(f"--- KeyError Handler: {e} ---")
-    return jsonify({"error": "KeyError in request data", "details": str(e)}), 500
+    @_blueprint.errorhandler(KeyError)
+    def handle_key_error(e):
+        print(f"--- KeyError Handler: {e} ---")
+        return jsonify({"error": "KeyError in request data", "details": str(e)}), 500
 
-@bp.app_errorhandler(Exception) # Catch-all for other unhandled exceptions
-def handle_generic_exception(e):
-    print(f"--- Generic Exception Handler: {type(e).__name__} - {e} ---")
-    import traceback
-    traceback.print_exc()
-    return jsonify({"error": "An unexpected server error occurred", "details": str(e)}), 500
+    @_blueprint.app_errorhandler(Exception) # Catch-all for other unhandled exceptions
+    def handle_generic_exception(e):
+        print(f"--- Generic Exception Handler: {type(e).__name__} - {e} ---")
+        import traceback
+        traceback.print_exc()
+        return jsonify({"error": "An unexpected server error occurred", "details": str(e)}), 500
+
+# Legacy bp attribute for backward compatibility
+def __getattr__(name):
+    if name == 'bp':
+        return get_blueprint()
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/test_fix.py
+++ b/test_fix.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that our Flask import fix works.
+"""
+
+import sys
+import os
+import types
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__))))
+
+# Set up environment
+os.environ.setdefault("OPENAI_API_KEY", "test-key-12345")
+
+# Mock Flask BEFORE any imports that might trigger Flask loading
+dummy_flask = types.SimpleNamespace(
+    Flask=object,
+    Blueprint=lambda *a, **k: types.SimpleNamespace(
+        route=lambda *a, **k: (lambda f: f),
+        errorhandler=lambda *a, **k: (lambda f: f),
+        app_errorhandler=lambda *a, **k: (lambda f: f),
+    ),
+    request=None,
+    render_template_string=lambda *a, **k: "",
+    render_template=lambda *a, **k: "",
+    Response=object,
+    stream_with_context=lambda f: f,
+    jsonify=lambda *a, **k: {},
+)
+sys.modules.setdefault("flask", dummy_flask)
+sys.modules.setdefault("flask_cors", types.SimpleNamespace(CORS=lambda *a, **k: None))
+
+print("✓ Flask mocking set up")
+
+# Now try to import our modules
+try:
+    # This should NOT trigger Flask imports
+    from mixologist.services.openai_service import Recipe, parse_recipe_arguments
+    print("✓ Successfully imported from openai_service without Flask conflicts")
+    
+    # Test recipe construction
+    recipe = Recipe(
+        [], 0.2, [], False, [], "", "", "", "Test Cocktail",
+        [], [], [], 0, 0, [], None, None, {}, [], [], [], "", "", []
+    )
+    print(f"✓ Recipe created: {recipe.drink_name}")
+    
+    # Test parse_recipe_arguments
+    test_data = {"drink_name": "Test"}
+    result = parse_recipe_arguments(test_data)
+    print(f"✓ parse_recipe_arguments works: {result.drink_name}")
+    
+    # Now test bartender imports (this should use mocked Flask)
+    from mixologist.views.bartender import bp
+    print(f"✓ Successfully imported bp: {type(bp)}")
+    
+    print("\n🎉 All tests passed! The Flask import fix is working.")
+    
+except Exception as e:
+    print(f"✗ Error: {e}")
+    import traceback
+    traceback.print_exc()


### PR DESCRIPTION
Fixes #39

Resolves Python test failures caused by Flask import conflicts.

## Changes
- Implement lazy Flask imports to avoid module-level Flask loading
- Refactor bartender.py to use get_blueprint() function with deferred route registration
- Update __init__.py to use lazy blueprint creation
- Add __getattr__ for backward compatibility

## Testing
Tests can now properly mock Flask before any real Flask imports occur.

Generated with [Claude Code](https://claude.ai/code)