### PR TITLE
fix: wrap Material dropdown widgets to resolve iOS compatibility issues

### DIFF
--- a/flutter_app/lib/pages/add_inventory_item_page.dart
+++ b/flutter_app/lib/pages/add_inventory_item_page.dart
@@ -151,57 +151,61 @@ class _AddInventoryItemPageState extends State<AddInventoryItemPage> {
             const SizedBox(height: 16),
 
             // Category Dropdown
-            DropdownButtonFormField<String>(
-              value: _selectedCategory,
-              decoration: const InputDecoration(
-                labelText: 'Category *',
-                border: OutlineInputBorder(),
+            Material(
+              child: DropdownButtonFormField<String>(
+                value: _selectedCategory,
+                decoration: const InputDecoration(
+                  labelText: 'Category *',
+                  border: OutlineInputBorder(),
+                ),
+                items: IngredientCategory.all.map((category) {
+                  return DropdownMenuItem(
+                    value: category,
+                    child: Text(IngredientCategory.getDisplayName(category)),
+                  );
+                }).toList(),
+                onChanged: (value) {
+                  setState(() {
+                    _selectedCategory = value!;
+                  });
+                },
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please select a category';
+                  }
+                  return null;
+                },
               ),
-              items: IngredientCategory.all.map((category) {
-                return DropdownMenuItem(
-                  value: category,
-                  child: Text(IngredientCategory.getDisplayName(category)),
-                );
-              }).toList(),
-              onChanged: (value) {
-                setState(() {
-                  _selectedCategory = value!;
-                });
-              },
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please select a category';
-                }
-                return null;
-              },
             ),
 
             const SizedBox(height: 16),
 
             // Quantity Dropdown
-            DropdownButtonFormField<String>(
-              value: _selectedQuantity,
-              decoration: const InputDecoration(
-                labelText: 'Quantity *',
-                border: OutlineInputBorder(),
+            Material(
+              child: DropdownButtonFormField<String>(
+                value: _selectedQuantity,
+                decoration: const InputDecoration(
+                  labelText: 'Quantity *',
+                  border: OutlineInputBorder(),
+                ),
+                items: QuantityDescription.all.map((quantity) {
+                  return DropdownMenuItem(
+                    value: quantity,
+                    child: Text(QuantityDescription.getDisplayName(quantity)),
+                  );
+                }).toList(),
+                onChanged: (value) {
+                  setState(() {
+                    _selectedQuantity = value!;
+                  });
+                },
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please select a quantity';
+                  }
+                  return null;
+                },
               ),
-              items: QuantityDescription.all.map((quantity) {
-                return DropdownMenuItem(
-                  value: quantity,
-                  child: Text(QuantityDescription.getDisplayName(quantity)),
-                );
-              }).toList(),
-              onChanged: (value) {
-                setState(() {
-                  _selectedQuantity = value!;
-                });
-              },
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please select a quantity';
-                }
-                return null;
-              },
             ),
 
             const SizedBox(height: 16),

--- a/flutter_app/lib/pages/unified_inventory_page.dart
+++ b/flutter_app/lib/pages/unified_inventory_page.dart
@@ -348,22 +348,24 @@ class _UnifiedInventoryPageState extends State<UnifiedInventoryPage> {
                   ),
                 ),
                 const SizedBox(width: 16),
-                DropdownButton<String>(
-                  value: _selectedCategory,
-                  items: [
-                    const DropdownMenuItem(value: 'all', child: Text('All Categories')),
-                    ...IngredientCategory.all.map(
-                      (category) => DropdownMenuItem(
-                        value: category,
-                        child: Text(IngredientCategory.getDisplayName(category)),
+                Material(
+                  child: DropdownButton<String>(
+                    value: _selectedCategory,
+                    items: [
+                      const DropdownMenuItem(value: 'all', child: Text('All Categories')),
+                      ...IngredientCategory.all.map(
+                        (category) => DropdownMenuItem(
+                          value: category,
+                          child: Text(IngredientCategory.getDisplayName(category)),
+                        ),
                       ),
-                    ),
-                  ],
-                  onChanged: (value) {
-                    setState(() {
-                      _selectedCategory = value ?? 'all';
-                    });
-                  },
+                    ],
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedCategory = value ?? 'all';
+                      });
+                    },
+                  ),
                 ),
               ],
             ),

--- a/flutter_app/lib/widgets/add_item_dialog.dart
+++ b/flutter_app/lib/widgets/add_item_dialog.dart
@@ -186,57 +186,61 @@ class _AddItemDialogState extends State<AddItemDialog> {
                 const SizedBox(height: 16),
 
                 // Category Dropdown
-                DropdownButtonFormField<String>(
-                  value: _selectedCategory,
-                  decoration: const InputDecoration(
-                    labelText: 'Category *',
-                    border: OutlineInputBorder(),
+                Material(
+                  child: DropdownButtonFormField<String>(
+                    value: _selectedCategory,
+                    decoration: const InputDecoration(
+                      labelText: 'Category *',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: IngredientCategory.all.map((category) {
+                      return DropdownMenuItem(
+                        value: category,
+                        child: Text(IngredientCategory.getDisplayName(category)),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedCategory = value!;
+                      });
+                    },
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please select a category';
+                      }
+                      return null;
+                    },
                   ),
-                  items: IngredientCategory.all.map((category) {
-                    return DropdownMenuItem(
-                      value: category,
-                      child: Text(IngredientCategory.getDisplayName(category)),
-                    );
-                  }).toList(),
-                  onChanged: (value) {
-                    setState(() {
-                      _selectedCategory = value!;
-                    });
-                  },
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please select a category';
-                    }
-                    return null;
-                  },
                 ),
 
                 const SizedBox(height: 16),
 
                 // Quantity Dropdown
-                DropdownButtonFormField<String>(
-                  value: _selectedQuantity,
-                  decoration: const InputDecoration(
-                    labelText: 'Quantity *',
-                    border: OutlineInputBorder(),
+                Material(
+                  child: DropdownButtonFormField<String>(
+                    value: _selectedQuantity,
+                    decoration: const InputDecoration(
+                      labelText: 'Quantity *',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: QuantityDescription.all.map((quantity) {
+                      return DropdownMenuItem(
+                        value: quantity,
+                        child: Text(QuantityDescription.getDisplayName(quantity)),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedQuantity = value!;
+                      });
+                    },
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please select a quantity';
+                      }
+                      return null;
+                    },
                   ),
-                  items: QuantityDescription.all.map((quantity) {
-                    return DropdownMenuItem(
-                      value: quantity,
-                      child: Text(QuantityDescription.getDisplayName(quantity)),
-                    );
-                  }).toList(),
-                  onChanged: (value) {
-                    setState(() {
-                      _selectedQuantity = value!;
-                    });
-                  },
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please select a quantity';
-                    }
-                    return null;
-                  },
                 ),
 
                 const SizedBox(height: 16),


### PR DESCRIPTION
Fixes #65

- Fixed "No Material widget found" error for DropdownButton widgets on iOS
- Wrapped DropdownButtonFormField and DropdownButton in Material widgets
- Maintains iOS theming while providing required Material context
- Resolves inventory functionality breaking on iOS platform

Generated with [Claude Code](https://claude.ai/code)