### PR TITLE
fix: complete iOS compatibility fixes for Material widgets

### DIFF
--- a/flutter_app/lib/pages/unified_inventory_page.dart
+++ b/flutter_app/lib/pages/unified_inventory_page.dart
@@ -348,22 +348,24 @@ class _UnifiedInventoryPageState extends State<UnifiedInventoryPage> {
                   ),
                 ),
                 const SizedBox(width: 16),
-                DropdownButton<String>(
-                  value: _selectedCategory,
-                  items: [
-                    const DropdownMenuItem(value: 'all', child: Text('All Categories')),
-                    ...IngredientCategory.all.map(
-                      (category) => DropdownMenuItem(
-                        value: category,
-                        child: Text(IngredientCategory.getDisplayName(category)),
+                Material(
+                  child: DropdownButton<String>(
+                    value: _selectedCategory,
+                    items: [
+                      const DropdownMenuItem(value: 'all', child: Text('All Categories')),
+                      ...IngredientCategory.all.map(
+                        (category) => DropdownMenuItem(
+                          value: category,
+                          child: Text(IngredientCategory.getDisplayName(category)),
+                        ),
                       ),
-                    ),
-                  ],
-                  onChanged: (value) {
-                    setState(() {
-                      _selectedCategory = value ?? 'all';
-                    });
-                  },
+                    ],
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedCategory = value ?? 'all';
+                      });
+                    },
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
Fixes #65

- Fixed remaining DropdownButton widget that was missing Material wrapper
- Resolves "No Material widget found" errors on iOS for all dropdown widgets
- Completes the iOS icon/widget compatibility fixes
- Maintains iOS theming while providing required Material context

Generated with [Claude Code](https://claude.ai/code)