### PR TITLE
Implement liquid ingredient flow widgets

### DIFF
--- a/flutter_app/lib/flow/flow_animation_controller.dart
+++ b/flutter_app/lib/flow/flow_animation_controller.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Provides a single ticker for all flow related animations.
+class FlowAnimationController {
+  FlowAnimationController(this.vsync)
+      : controller = AnimationController.unbounded(vsync: vsync);
+
+  final TickerProvider vsync;
+  final AnimationController controller;
+
+  /// Helper to stagger animations.
+  Duration stagger(int milliseconds) => Duration(milliseconds: milliseconds);
+
+  void dispose() {
+    controller.dispose();
+  }
+}

--- a/flutter_app/lib/flow/widgets/bubble_burst.dart
+++ b/flutter_app/lib/flow/widgets/bubble_burst.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:particles_flutter/particles_flutter.dart';
+
+/// Simple bubble burst particle effect used when an ingredient is checked.
+class BubbleBurst extends StatelessWidget {
+  final Color color;
+  const BubbleBurst(this.color, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CircularParticle(
+      numberOfParticles: 5,
+      particleColor: color,
+      awayRadius: 80,
+      maxParticleSize: 4,
+      isRandSize: true,
+      awayAnimationDuration: 600,
+    );
+  }
+}

--- a/flutter_app/lib/flow/widgets/liquid_drop.dart
+++ b/flutter_app/lib/flow/widgets/liquid_drop.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:liquid_progress_indicator/liquid_progress_indicator.dart';
+
+/// A teardrop shaped liquid progress indicator used to visualize ingredient
+/// completion. The fill level rises from bottom to top and the color can be
+/// customized per ingredient category.
+class LiquidDrop extends StatelessWidget {
+  const LiquidDrop({Key? key, required this.value, required this.color}) : super(key: key);
+
+  /// Fill value from 0 to 1.
+  final double value;
+
+  /// Color of the liquid.
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipPath(
+      clipper: _TeardropClipper(),
+      child: Container(
+        decoration: const BoxDecoration(boxShadow: [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: 2,
+            offset: Offset(0, 1),
+          )
+        ]),
+        child: LiquidCircularProgressIndicator(
+          value: value.clamp(0.0, 1.0),
+          valueColor: AlwaysStoppedAnimation<Color>(color),
+          backgroundColor: color.withOpacity(0.15),
+          direction: Axis.vertical,
+        ),
+      ),
+    );
+  }
+}
+
+/// Simple teardrop clipper used to shape the progress indicator.
+class _TeardropClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    final path = Path();
+    path.moveTo(size.width / 2, 0);
+    path.quadraticBezierTo(size.width, 0, size.width, size.height * 0.6);
+    path.arcToPoint(
+      Offset(0, size.height * 0.6),
+      radius: Radius.circular(size.width),
+      clockwise: false,
+    );
+    path.quadraticBezierTo(0, 0, size.width / 2, 0);
+    return path;
+  }
+
+  @override
+  bool shouldReclip(covariant _TeardropClipper oldClipper) => false;
+}

--- a/flutter_app/lib/flow/widgets/tube_connector.dart
+++ b/flutter_app/lib/flow/widgets/tube_connector.dart
@@ -1,0 +1,57 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+/// Animated tube connector that visually links two LiquidDrop widgets.
+class TubeConnector extends StatelessWidget {
+  const TubeConnector({Key? key, required this.l, required this.r}) : super(key: key);
+
+  /// Color on the left side.
+  final Color l;
+
+  /// Color on the right side.
+  final Color r;
+
+  @override
+  Widget build(BuildContext context) {
+    return Animate(
+      onPlay: (controller) => controller.repeat(),
+      effects: [
+        MoveEffect(duration: 1.5.seconds, curve: Curves.easeInOut),
+      ],
+      child: CustomPaint(
+        painter: _TubePainter(shader: _tubeShader(l, r)),
+        size: const Size(double.infinity, 16),
+      ),
+    );
+  }
+
+  Shader _tubeShader(Color left, Color right) {
+    return LinearGradient(
+      colors: [left, right],
+    ).createShader(const Rect.fromLTWH(0, 0, 200, 16));
+  }
+}
+
+class _TubePainter extends CustomPainter {
+  _TubePainter({required this.shader});
+
+  final Shader shader;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..shader = shader
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+    final path = Path()
+      ..moveTo(0, size.height / 2)
+      ..lineTo(size.width, size.height / 2);
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _TubePainter oldDelegate) => false;
+}

--- a/flutter_app/lib/providers/ingredient_provider.dart
+++ b/flutter_app/lib/providers/ingredient_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+class Ingredient {
+  Ingredient(this.name, {this.checked = false, this.fill = 0});
+  final String name;
+  bool checked;
+  double fill;
+}
+
+class IngredientNotifier extends StateNotifier<List<Ingredient>> {
+  IngredientNotifier() : super([]);
+
+  void toggleCheck(int index) {
+    final item = state[index];
+    item.checked = !item.checked;
+    item.fill = item.checked ? 1.0 : 0.0;
+    // Placeholder for analytics hook
+    state = [...state];
+  }
+}
+
+final ingredientProvider =
+    StateNotifierProvider<IngredientNotifier, List<Ingredient>>(
+        (ref) => IngredientNotifier());

--- a/flutter_app/lib/theme/cocktail_theme.dart
+++ b/flutter_app/lib/theme/cocktail_theme.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Ingredient categories used to color liquid drops.
+enum IngredientCategory { spirit, citrus, mixer }
+
+/// Theme extension containing swatches for each ingredient category.
+class CocktailTheme extends ThemeExtension<CocktailTheme> {
+  CocktailTheme({
+    required this.spirit,
+    required this.citrus,
+    required this.mixer,
+  });
+
+  final Color spirit;
+  final Color citrus;
+  final Color mixer;
+
+  @override
+  CocktailTheme copyWith({Color? spirit, Color? citrus, Color? mixer}) {
+    return CocktailTheme(
+      spirit: spirit ?? this.spirit,
+      citrus: citrus ?? this.citrus,
+      mixer: mixer ?? this.mixer,
+    );
+  }
+
+  @override
+  CocktailTheme lerp(ThemeExtension<CocktailTheme>? other, double t) {
+    if (other is! CocktailTheme) return this;
+    return CocktailTheme(
+      spirit: Color.lerp(spirit, other.spirit, t)!,
+      citrus: Color.lerp(citrus, other.citrus, t)!,
+      mixer: Color.lerp(mixer, other.mixer, t)!,
+    );
+  }
+}
+
+/// Returns a color blended between the two categories.
+Color lerpCategory(IngredientCategory a, IngredientCategory b, CocktailTheme theme) {
+  Color first = _catColor(a, theme);
+  Color second = _catColor(b, theme);
+  return Color.lerp(first, second, 0.5)!;
+}
+
+Color _catColor(IngredientCategory c, CocktailTheme theme) {
+  switch (c) {
+    case IngredientCategory.spirit:
+      return theme.spirit;
+    case IngredientCategory.citrus:
+      return theme.citrus;
+    case IngredientCategory.mixer:
+      return theme.mixer;
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -29,6 +29,10 @@ dependencies:
   just_audio: ^0.9.36
   # Fuzzy search for cocktail name matching
   fuzzy: ^0.5.1
+  liquid_progress_indicator: ^0.4.0
+  flutter_animate: ^4.2.0
+  particles_flutter: ^0.1.3
+  flutter_riverpod: ^2.4.0
 
 
 flutter:

--- a/flutter_app/test/flow/liquid_drop_test.dart
+++ b/flutter_app/test/flow/liquid_drop_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mixologist_flutter/flow/widgets/liquid_drop.dart';
+
+void main() {
+  testWidgets('LiquidDrop renders with value and color', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LiquidDrop(value: 0.5, color: Colors.red),
+        ),
+      ),
+    );
+    expect(find.byType(LiquidDrop), findsOneWidget);
+  });
+}

--- a/mixologist/models/get_recipe_params.py
+++ b/mixologist/models/get_recipe_params.py
@@ -1,9 +1,9 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr
 from typing import List, Dict, Optional
 
 class Ingredient(BaseModel):
-    name: str = Field(..., description="Name of the ingredient")
-    quantity: str = Field(..., description="Quantity of the ingredient")
+    name: StrictStr = Field(..., description="Name of the ingredient")
+    quantity: StrictStr = Field(..., description="Quantity of the ingredient")
 
 class BrandRecommendation(BaseModel):
     ingredient: str = Field(..., description="Name of the ingredient")


### PR DESCRIPTION
## Summary
- add liquid drop, tube connector, bubble burst widgets
- add central flow animation controller
- add ingredient provider using riverpod
- extend theme for ingredient colors
- enforce strict string types for recipe ingredient model
- include widget test for liquid drop

## Testing
- `pip install openai httpx aiofiles python-dotenv sqlalchemy motor asyncpg aiosqlite python-multipart`
- `pytest -q` *(fails: 1 test initially)*
- fixed validation logic, now:
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b65b90c883219f67aa48fbb6af83